### PR TITLE
docs: susun ulang README mengikuti pola readme-generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,29 @@
-# Absensi — Aplikasi Absensi & HRIS
+# Absensi
 
 Sistem absensi berbasis pemindaian QR yang berkembang menjadi HRIS: penggajian,
-cuti, kasbon, dokumen karyawan, pajak & BPJS, serta portal layanan mandiri.
+cuti, kasbon, dokumen karyawan, pajak & BPJS, serta portal layanan mandiri
+karyawan.
 
-Dibangun dengan Laravel 10 dan Backpack CRUD 6 (edisi gratis).
+Dibangun dengan Laravel 10 dan Backpack CRUD 6 (edisi gratis) di atas MySQL 8.
+
+**Dokumentasi:** [Panduan Pengguna](docs/PANDUAN-PENGGUNA.md) ·
+[Panduan Developer](docs/PANDUAN-DEVELOPER.md)
+
+---
+
+## Daftar isi
+
+- [Fitur](#fitur)
+- [Prasyarat](#prasyarat)
+- [Pemasangan](#pemasangan)
+- [Cara pakai](#cara-pakai)
+- [Pengembangan](#pengembangan)
+- [Pengujian](#pengujian)
+- [Dokumentasi](#dokumentasi)
+- [Catatan penerapan](#catatan-penerapan)
+- [Rencana pengembangan](#rencana-pengembangan)
+- [Kontribusi](#kontribusi)
+- [Lisensi](#lisensi)
 
 ---
 
@@ -15,19 +35,35 @@ Dibangun dengan Laravel 10 dan Backpack CRUD 6 (edisi gratis).
 | **Penggajian** | Komponen gaji, lembur, denda keterlambatan, rekap bulanan, slip gaji PDF |
 | **Kasbon** | Penerbitan kasbon, pencatatan cicilan, potongan otomatis dari gaji |
 | **Cuti & Izin** | Pengajuan, kuota tahunan dengan carry-over, kalender, rekap |
-| **Persetujuan** | Alur bertingkat per modul, approver berdasarkan role / atasan / user tertentu |
-| **Organisasi** | Cabang, departemen bersarang, jabatan, struktur organisasi |
+| **Persetujuan** | Alur bertingkat per modul; approver berdasarkan peran, atasan, atau user tertentu |
+| **Organisasi** | Cabang, departemen bersarang, jabatan, bagan struktur |
 | **Dokumen** | Dokumen karyawan di penyimpanan privat, checklist kelengkapan, peringatan kedaluwarsa |
 | **Pajak & BPJS** | PPh 21 progresif, PTKP, BPJS Kesehatan/JHT/JP/JKK/JKM, THR |
-| **Portal Karyawan** | `/my` — riwayat kehadiran, slip gaji, cuti, kasbon, profil, notifikasi |
+| **Portal Karyawan** | Riwayat kehadiran, slip gaji, cuti, kasbon, profil, notifikasi |
 | **Dashboard & Laporan** | Ringkasan harian, tren 12 bulan, laporan kehadiran/gaji/kasbon/headcount |
-| **Audit & Notifikasi** | Jejak audit seluruh perubahan; notifikasi database, email, dan WhatsApp |
+| **Audit & Notifikasi** | Jejak audit seluruh perubahan; kanal database, email, dan WhatsApp |
+
+Hak akses dibagi empat peran — `super_admin`, `hr_admin`, `manager`, `employee`
+— dan ditegakkan di dua lapis: middleware pada route group, serta pembatasan
+operasi di controller. Manager hanya melihat bawahan langsungnya.
 
 ---
 
-## Menjalankan secara lokal
+## Prasyarat
 
-Prasyarat: PHP 8.1+, Composer, Docker, Node 18+ (hanya untuk pengujian browser).
+| Kebutuhan | Versi |
+|---|---|
+| PHP | 8.1 atau lebih baru |
+| Composer | 2.x |
+| Docker | untuk MySQL 8 |
+| Node.js | 18+ — hanya bila menjalankan pengujian browser |
+
+Ekstensi PHP yang dibutuhkan mengikuti kebutuhan standar Laravel 10, ditambah
+`gd` untuk pembuatan QR dan kartu karyawan.
+
+---
+
+## Pemasangan
 
 ```bash
 git clone git@github.com:agitnaeta/absensi.git
@@ -36,14 +72,13 @@ cd absensi
 composer install
 cp .env.example .env
 php artisan key:generate
-
-docker compose up -d          # MySQL 8 di port host 3307
-php artisan migrate
-php artisan db:seed --class=HrisSeeder      # data referensi, idempoten
-php artisan serve
 ```
 
-Sesuaikan `.env` agar menunjuk ke container:
+Jalankan basis data, lalu sesuaikan `.env`:
+
+```bash
+docker compose up -d          # MySQL 8 pada port host 3307
+```
 
 ```env
 DB_CONNECTION=mysql
@@ -54,15 +89,49 @@ DB_USERNAME=root
 DB_PASSWORD=secret
 ```
 
-Buka http://127.0.0.1:8000 — halaman muka adalah pemindai QR (`/scan`),
-panel admin di `/admin/login`.
+> `.env.example` mengirim `DB_PORT=3306`, sedangkan `docker-compose.yml`
+> memetakan MySQL ke **3307** supaya tidak bentrok dengan MySQL lokal. Ubah
+> manual setelah menyalin.
 
-Berikan role tertinggi ke akun pertama:
+Siapkan skema dan data referensi:
+
+```bash
+php artisan migrate
+php artisan db:seed --class=HrisSeeder      # peran, izin, alur persetujuan, tarif pajak
+php artisan serve
+```
+
+`HrisSeeder` bersifat idempoten — aman dijalankan ulang setelah pembaruan.
+
+Berikan peran tertinggi ke akun pertama:
 
 ```bash
 php artisan tinker
 >>> \App\Models\User::find(1)->assignRole('super_admin');
 ```
+
+---
+
+## Cara pakai
+
+Aplikasi punya tiga pintu masuk:
+
+| Alamat | Untuk siapa | Perlu login |
+|---|---|---|
+| `/scan` | Pemindai QR di pintu masuk kantor | tidak |
+| `/admin/login` | HR, manager, super admin | ya |
+| `/my` | Karyawan — portal layanan mandiri | ya |
+
+Membuka `/` akan mengarahkan ke `/scan`.
+
+Alur harian paling umum: karyawan menunjukkan QR di kartunya ke kamera pada
+halaman `/scan`. Pemindaian pertama tercatat sebagai jam masuk, berikutnya
+sebagai jam keluar. Keterlambatan, lembur, dan pemeriksaan lokasi dihitung
+otomatis.
+
+Untuk tugas selengkapnya — menambah karyawan, menjalankan penggajian,
+menyetujui cuti, mengelola kuota — lihat
+**[Panduan Pengguna](docs/PANDUAN-PENGGUNA.md)** yang disusun per peran.
 
 ### Data demo
 
@@ -70,15 +139,15 @@ php artisan tinker
 php artisan db:seed --class=DemoDataSeeder   # menolak berjalan di production
 ```
 
-Membuat perusahaan lima orang dengan satu bulan kehadiran penuh, cuti yang
-disetujui dan yang pending, satu kasbon, serta satu siklus penggajian.
+Membuat perusahaan lima orang dengan satu bulan kehadiran penuh, cuti yang sudah
+disetujui dan yang masih menunggu, satu kasbon, serta satu siklus penggajian.
 
-| Email | Password | Role |
+| Email | Password | Peran |
 |---|---|---|
 | `siti@demo.test` | `password` | super_admin |
 | `rina@demo.test` | `password` | hr_admin |
 | `budi@demo.test` | `password` | manager |
-| `ahmad@demo.test` · `dewi@demo.test` | `password` | employee |
+| `ahmad@demo.test`, `dewi@demo.test` | `password` | employee |
 
 Data sengaja ditempatkan di **bulan sebelumnya**: rekap gaji mengukur satu bulan
 penuh, sehingga bulan berjalan yang baru separuh akan terbaca seperti absen
@@ -86,108 +155,166 @@ massal.
 
 ---
 
-## Role
+## Pengembangan
 
-| Role | Cakupan |
-|---|---|
-| `super_admin` | Seluruh akses, termasuk role, permission, dan alur persetujuan |
-| `hr_admin` | Seluruh operasi HR. Tidak boleh mengubah role, permission, atau alur persetujuan |
-| `manager` | Melihat timnya (bawahan langsung) dan bertindak atas persetujuan. Hanya izin baca |
-| `employee` | Portal layanan mandiri saja |
+Struktur kode mengikuti satu aturan utama: **logika bisnis berada di Service,
+bukan di controller.** Controller Backpack hanya mengatur field, kolom, dan hak
+akses.
 
-Hak akses ditegakkan di dua lapis: middleware `permission:` pada route group, dan
-`denyAccess` di controller untuk modul yang boleh dibaca tetapi tidak ditulis.
-Daftar karyawan dan presensi disempitkan lewat `User::scopeVisibleTo()`.
+```
+app/
+├── Http/Controllers/Admin/     29 CRUD controller
+├── Http/Controllers/Portal/    seluruh /my/*
+├── Services/                   aturan bisnis sesungguhnya
+├── Observers/                  perhitungan turunan presensi & gaji
+└── Traits/                     Auditable, HasApproval, HasSimpleFilters
+```
 
-> **Dua guard.** Backpack mengautentikasi admin pada guard `backpack`, sedangkan
-> role Spatie tersimpan pada guard `web`. Akibatnya `@can` dan `@role` bawaan
-> **selalu false** untuk admin yang login. Di view admin gunakan
-> `backpack_user()->can(...)`.
+Sebelum menyentuh kode, baca bagian **empat jebakan** di
+**[Panduan Developer](docs/PANDUAN-DEVELOPER.md)**. Ringkasnya:
 
----
+1. Backpack memakai guard `backpack`, sedangkan peran Spatie tersimpan di guard
+   `web` — sehingga `@can` dan `@role` bawaan **selalu false** untuk admin
+2. Model CRUD wajib memakai `CrudTrait`, karena itu `Role` dan `Permission`
+   punya pembungkus lokal
+3. `addFilter()` berbayar di edisi gratis; penggantinya trait `HasSimpleFilters`
+4. Baris tabel dimuat lewat AJAX, dan `recordsTotal` bukan angka yang
+   ditampilkan — `recordsFiltered` yang benar
 
-## Perintah terjadwal
+### Perintah artisan
 
-| Jadwal | Perintah |
-|---|---|
-| Hari kerja 08:15 | `notify:attendance --type=checkin` |
-| Hari kerja 09:30 | `notify:attendance --type=late` |
-| Hari kerja 17:00 | `notify:attendance --type=checkout` |
-| Senin 07:30 | `documents:notify-expiring --days=30` |
-| Senin 08:00 | `notify:approval-digest` |
-| Harian 23:00 | `backup:run --only-db` |
-| Harian 23:30 | `db:seed RecalculatePresence` |
-| Bulanan tgl 1, 02:00 | `audit:prune --days=90` |
-| Tahunan | `leave:generate-balances --carry-over --max-carry=6` |
+| Perintah | Fungsi | Jadwal |
+|---|---|---|
+| `notify:attendance --type=checkin` | Belum absen masuk | hari kerja 08:15 |
+| `notify:attendance --type=late` | Terlambat | hari kerja 09:30 |
+| `notify:attendance --type=checkout` | Belum absen keluar | hari kerja 17:00 |
+| `documents:notify-expiring --days=30` | Dokumen mendekati kedaluwarsa | Senin 07:30 |
+| `notify:approval-digest` | Ringkasan persetujuan tertunda | Senin 08:00 |
+| `backup:run --only-db` | Cadangan basis data | harian 23:00 |
+| `db:seed RecalculatePresence` | Hitung ulang presensi | harian 23:30 |
+| `audit:prune --days=90` | Pangkas jejak audit | bulanan tgl 1, 02:00 |
+| `leave:generate-balances --carry-over --max-carry=6` | Saldo cuti tahunan | tahunan |
+| `calculate:salary` | Hitung rekap gaji | manual |
+| `salary:recalculate` | Hitung ulang gaji per user/bulan | manual |
+| `import:presence-command` | Impor presensi | manual |
 
-Perintah manual: `calculate:salary`, `salary:recalculate`, `import:presence-command`.
+Penjadwalan berjalan lewat `php artisan schedule:work` atau cron. Log aplikasi
+bisa dibaca di `/log-viewer`.
 
 ---
 
 ## Pengujian
 
+Dua lapis, keduanya perlu dijalankan sebelum rilis.
+
 ```bash
-./vendor/bin/phpunit                    # 150 test, skema absensi_testing terpisah
+./vendor/bin/phpunit
 ```
 
-Pengujian berbasis browser (Chromium sungguhan) untuk hal yang tidak terjangkau
-PHPUnit — tabel Backpack dimuat lewat AJAX, sehingga mengambil URL daftar saja
-hanya menghasilkan kerangka tabel kosong:
+150 test pada skema `absensi_testing` yang terpisah, jadi tidak menyentuh data
+pengembangan.
 
 ```bash
 npm install && npx playwright install chromium
-php artisan serve                       # aplikasi harus berjalan
-node tests/browser/crud-suite.mjs       # 146 pemeriksaan siklus CRUD & hak akses
+php artisan serve                       # aplikasi harus berjalan lebih dulu
+node tests/browser/crud-suite.mjs       # 146 pemeriksaan CRUD & hak akses
 node tests/browser/ui-test.mjs          # rendering dashboard, menu, portal
 ```
+
+Pengujian browser menutup hal yang tidak terjangkau PHPUnit: tabel yang dimuat
+lewat AJAX, rendering grafik, visibilitas menu per peran, dan route publik yang
+diakses tanpa login.
 
 > `crud-suite.mjs` **mengubah data**. Cadangkan lebih dulu:
 > ```bash
 > docker exec absensi-mysql mysqldump -uroot -psecret --single-transaction absensi \
 >   > storage/app/backups/pre-crud-test.sql
 > ```
-> Pulihkan dengan `mysql` dan berkas yang sama.
+> Pulihkan dengan `mysql` memakai berkas yang sama.
 
 ---
 
 ## Dokumentasi
 
-**Mulai dari salah satu ini:**
+Mulai dari salah satu ini, sesuai kebutuhanmu:
 
-| Berkas | Untuk siapa |
+| Dokumen | Untuk siapa |
 |---|---|
-| [docs/PANDUAN-PENGGUNA.md](docs/PANDUAN-PENGGUNA.md) | **Pengguna** — HR, manager, karyawan. Berorientasi tugas, per peran |
-| [docs/PANDUAN-DEVELOPER.md](docs/PANDUAN-DEVELOPER.md) | **Developer** — arsitektur, konvensi, jebakan, cara menambah modul |
+| **[Panduan Pengguna](docs/PANDUAN-PENGGUNA.md)** | HR, manager, karyawan. Berorientasi tugas, disusun per peran, dilengkapi tanya-jawab |
+| **[Panduan Developer](docs/PANDUAN-DEVELOPER.md)** | Arsitektur, konvensi, jebakan yang perlu diketahui, cara menambah modul |
 
 Rujukan lebih dalam:
 
-| Berkas | Isi |
+| Dokumen | Isi |
 |---|---|
-| [docs/HRIS_SETUP.md](docs/HRIS_SETUP.md) | Referensi modul M0–M8, keputusan arsitektur, batasan Backpack edisi gratis |
-| [docs/BUSINESS_FLOW.md](docs/BUSINESS_FLOW.md) | Alur bisnis |
-| [docs/test-cases/](docs/test-cases/README.md) | 725 test case CRUD operasional per modul |
-| [docs/bug-list/](docs/bug-list/README.md) | 12 bug beserta akar masalah dan perbaikannya |
-| [docs/UI_TEST_CASES.md](docs/UI_TEST_CASES.md) | Test case UI lintas modul + matriks akses per role |
-| [docs/MODULE_PLANS.md](docs/MODULE_PLANS.md) | Rencana modul |
+| [HRIS_SETUP.md](docs/HRIS_SETUP.md) | Referensi modul M0–M8 dan keputusan arsitekturnya |
+| [BUSINESS_FLOW.md](docs/BUSINESS_FLOW.md) | Alur bisnis |
+| [test-cases/](docs/test-cases/README.md) | 725 test case CRUD operasional per modul |
+| [bug-list/](docs/bug-list/README.md) | 12 bug beserta akar masalah dan perbaikannya |
+| [UI_TEST_CASES.md](docs/UI_TEST_CASES.md) | Test case UI lintas modul dan matriks akses per peran |
+| [MODULE_PLANS.md](docs/MODULE_PLANS.md) | Rencana modul |
 
 ---
 
 ## Catatan penerapan
 
 **Tarif pajak wajib diverifikasi.** `TaxRateSeeder` mengacu PMK 101/2016 dan
-UU HPP No. 7/2021 saat ditulis, dan JKK diisi kelas risiko terendah (0,24%).
-PTKP, lapisan PPh 21, dan persentase BPJS disimpan **per tahun** agar
-perhitungan historis memakai tarif periodenya sendiri — periksa nilainya
-terhadap regulasi terbaru sebelum menjalankan payroll sungguhan.
+UU HPP No. 7/2021 pada saat ditulis, dengan JKK kelas risiko terendah (0,24%).
+PTKP, lapisan PPh 21, dan persentase BPJS disimpan **per tahun** supaya
+perhitungan historis memakai tarif periodenya sendiri. Periksa nilainya terhadap
+regulasi terbaru sebelum menjalankan penggajian sungguhan.
 
-**Single-tenant.** Satu instalasi untuk satu perusahaan. Tabel `branches` dan
-`departments` adalah struktur di dalam satu perusahaan, bukan pemisah antar
-pelanggan; tidak ada kolom tenant di tabel inti.
+**Aplikasi ini single-tenant.** Satu instalasi untuk satu perusahaan. Tabel
+`branches` dan `departments` adalah struktur di dalam satu perusahaan, bukan
+pemisah antar pelanggan; tidak ada kolom tenant di tabel inti.
 
-**Dokumen karyawan** disimpan di disk `local` (privat), bukan `public`. Unduhan
-mengalir lewat aplikasi setelah pemeriksaan hak akses.
+**Dokumen karyawan** disimpan di disk `local` yang privat, bukan `public`.
+Unduhan mengalir lewat aplikasi setelah pemeriksaan hak akses.
 
-**WhatsApp** memakai `LogWhatsAppGateway` (hanya mencatat) sampai `FONNTE_TOKEN`
-diisi, sehingga tidak ada notifikasi yang berpura-pura terkirim.
+**WhatsApp** memakai `LogWhatsAppGateway` yang hanya mencatat, sampai
+`FONNTE_TOKEN` diisi — supaya tidak ada notifikasi yang berpura-pura terkirim.
 
 **Integrasi akuntansi** nonaktif kecuali `ACC_ACTIVE=true` diset di `.env`.
+
+Daftar periksa lengkap sebelum rilis ada di
+[Panduan Developer](docs/PANDUAN-DEVELOPER.md#sebelum-rilis).
+
+---
+
+## Rencana pengembangan
+
+Modul M0–M8 sudah dibangun. Tiga modul berikut direncanakan namun belum
+dikerjakan, dan ditandai prioritas rendah di
+[MODULE_PLANS.md](docs/MODULE_PLANS.md):
+
+- Rekrutmen
+- Manajemen kinerja
+- Pelatihan
+
+Satu celah fungsional yang diketahui: karyawan belum bisa mengunduh dokumennya
+sendiri dari portal, karena route dokumen di `/my` belum ada.
+
+---
+
+## Kontribusi
+
+1. Buat branch dari `master`
+2. Kalau menambah modul, ikuti urutan di
+   [Panduan Developer](docs/PANDUAN-DEVELOPER.md#menambah-modul-crud-baru) —
+   termasuk menambahkan izin di `RolesAndPermissionsSeeder`, langkah yang paling
+   sering terlewat
+3. Jalankan kedua lapis pengujian sampai hijau
+4. Tulis pesan commit yang menjelaskan **mengapa**, bukan hanya apa
+
+Temuan bug sebaiknya dicatat di [docs/bug-list/](docs/bug-list/README.md) dengan
+langkah reproduksi dan akar masalahnya, mengikuti format berkas yang sudah ada.
+
+---
+
+## Lisensi
+
+`composer.json` menyatakan **MIT**, warisan dari kerangka Laravel. Namun
+repositori ini **belum memiliki berkas `LICENSE`**.
+
+TODO: tambahkan berkas `LICENSE` yang sesuai, atau perbarui `composer.json` bila
+proyek ini bersifat tertutup.


### PR DESCRIPTION
Mengikuti struktur skill readme-generator dari GLINCKER/claude-code-marketplace. Versi sebelumnya sudah memuat isi yang benar tetapi urutannya belum mengikuti pola tersebut, dan beberapa bagian wajib belum ada.

Ditambahkan: Daftar isi, Prasyarat, Cara pakai, Pengembangan, Rencana pengembangan, Kontribusi, dan Lisensi. Bagian yang sudah ada disusun ulang mengikuti urutan skill: judul dan deskripsi, fitur, pemasangan, penggunaan, lalu lisensi.

Keputusan yang mengikuti aturan skill:

- **Tanpa badge.** Skill hanya meminta badge bila CI/CD terdeteksi. Discovery memastikan tidak ada .github/workflows, .gitlab-ci.yml, .circleci, Jenkinsfile, maupun .travis.yml.
- **Tanpa emoji.** Skill meminta emoji hanya bila pengguna memintanya.
- **Tanpa bagian Screenshots.** Berkasnya sudah dihapus dari repositori.
- **Penanda TODO pada Lisensi.** Skill meminta bagian yang informasinya kurang diberi penanda TODO. composer.json menyatakan MIT sebagai warisan kerangka Laravel, tetapi repositori ini tidak punya berkas LICENSE — jadi lisensinya belum bisa dinyatakan dengan pasti.

Kedua panduan ditautkan di tiga tempat agar tidak terlewat: tepat di bawah deskripsi, di dalam bagian Cara pakai dan Pengembangan, serta sebagai titik masuk utama di bagian Dokumentasi.

Seluruh 27 tautan diverifikasi, termasuk dua anchor ke panduan developer.